### PR TITLE
Remove associated data in wrapping of keys

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -344,7 +344,6 @@ mod test {
     fn credential_data() -> CredentialData {
         use ctap_types::webauthn::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity};
 
-        
         CredentialData {
             rp: PublicKeyCredentialRpEntity {
                 id: String::from("John Doe"),
@@ -424,7 +423,6 @@ mod test {
     fn random_credential_data() -> CredentialData {
         use ctap_types::webauthn::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity};
 
-        
         CredentialData {
             rp: PublicKeyCredentialRpEntity {
                 id: random_string(),

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -344,7 +344,8 @@ mod test {
     fn credential_data() -> CredentialData {
         use ctap_types::webauthn::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity};
 
-        let credential_data = CredentialData {
+        
+        CredentialData {
             rp: PublicKeyCredentialRpEntity {
                 id: String::from("John Doe"),
                 name: None,
@@ -362,8 +363,7 @@ mod test {
             key: Key::WrappedKey(Bytes::from_slice(&[1, 2, 3]).unwrap()),
             hmac_secret: Some(false),
             cred_protect: None,
-        };
-        credential_data
+        }
     }
 
     fn random_bytes<const N: usize>() -> Bytes<N> {
@@ -424,7 +424,8 @@ mod test {
     fn random_credential_data() -> CredentialData {
         use ctap_types::webauthn::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity};
 
-        let credential_data = CredentialData {
+        
+        CredentialData {
             rp: PublicKeyCredentialRpEntity {
                 id: random_string(),
                 name: maybe_random_string(),
@@ -442,8 +443,7 @@ mod test {
             key: Key::WrappedKey(random_bytes()),
             hmac_secret: Some(false),
             cred_protect: None,
-        };
-        credential_data
+        }
     }
 
     #[test]

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -252,7 +252,8 @@ impl Credential {
         let nonce: [u8; 12] = self.nonce.as_slice().try_into().unwrap();
         let encrypted_serialized_credential = EncryptedSerializedCredential(syscall!(trussed
             .encrypt_chacha8poly1305(key_encryption_key, message, associated_data, Some(&nonce))));
-        let credential_id: CredentialId = encrypted_serialized_credential.try_into()
+        let credential_id: CredentialId = encrypted_serialized_credential
+            .try_into()
             .map_err(|_| Error::RequestTooLarge)?;
 
         Ok(credential_id)

--- a/src/ctap1.rs
+++ b/src/ctap1.rs
@@ -63,7 +63,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
         let wrapped_key =
             syscall!(self
                 .trussed
-                .wrap_key_chacha8poly1305(wrapping_key, private_key, &reg.app_id,))
+                .wrap_key_chacha8poly1305(wrapping_key, private_key, &[]))
             .wrapped_key;
         // debug!("wrapped_key = {:?}", &wrapped_key);
 
@@ -208,7 +208,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 let key_result = syscall!(self.trussed.unwrap_key_chacha8poly1305(
                     wrapping_key,
                     bytes,
-                    b"",
+                    &[],
                     Location::Volatile,
                 ))
                 .key;

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -320,12 +320,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
             false => {
                 // WrappedKey version
                 let wrapping_key = self.state.persistent.key_wrapping_key(&mut self.trussed)?;
-                let wrapped_key = syscall!(self.trussed.wrap_key_chacha8poly1305(
-                    wrapping_key,
-                    private_key,
-                    &rp_id_hash,
-                ))
-                .wrapped_key;
+                let wrapped_key =
+                    syscall!(self
+                        .trussed
+                        .wrap_key_chacha8poly1305(wrapping_key, private_key, &[]))
+                    .wrapped_key;
 
                 // 32B key, 12B nonce, 16B tag + some info on algorithm (P256/Ed25519)
                 // Turns out it's size 92 (enum serialization not optimized yet...)
@@ -1465,8 +1464,7 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
                 let key_result = syscall!(self.trussed.unwrap_key_chacha8poly1305(
                     wrapping_key,
                     &bytes,
-                    b"",
-                    // &rp_id_hash,
+                    &[],
                     Location::Volatile,
                 ))
                 .key;

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -963,7 +963,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         let num_credentials = match num_credentials {
             1 => None,
-            n => Some(n as u32),
+            n => Some(n),
         };
 
         self.assert_with_credential(num_credentials, credential)
@@ -1543,19 +1543,12 @@ impl<UP: UserPresence, T: TrussedRequirements> crate::Authenticator<UP, T> {
         };
 
         debug_now!("signing with {:?}, {:?}", &mechanism, &serialization);
-        let signature = match mechanism {
-            // Mechanism::Totp => {
-            //     let timestamp = u64::from_le_bytes(data.client_data_hash[..8].try_into().unwrap());
-            //     info_now!("TOTP with timestamp {:?}", &timestamp);
-            //     syscall!(self.trussed.sign_totp(key, timestamp)).signature.to_bytes().unwrap()
-            // }
-            _ => syscall!(self
-                .trussed
-                .sign(mechanism, key, &commitment, serialization))
-            .signature
-            .to_bytes()
-            .unwrap(),
-        };
+        let signature = syscall!(self
+            .trussed
+            .sign(mechanism, key, &commitment, serialization))
+        .signature
+        .to_bytes()
+        .unwrap();
 
         if !is_rk {
             syscall!(self.trussed.delete(key));

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -112,9 +112,7 @@ where
 
     // Goal of these nested scopes is to keep stack small.
     let ctap_response = {
-        let ctap_request = {
-            ctap1::Request::try_from(command)?
-        };
+        let ctap_request = ctap1::Request::try_from(command)?;
         ctap1::Authenticator::call_ctap1(authenticator, &ctap_request)?
     };
     // debug!("1b SP: {:X}", msp());

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -35,7 +35,7 @@ fn handle_ctap1_from_hid<T, UP>(
     );
     {
         let command = apdu_dispatch::Command::try_from(data);
-        if let Err(status) = command {
+        if let Err(_status) = command {
             let code: [u8; 2] = (Status::IncorrectDataParameter).into();
             debug!("CTAP1 parse error: {:?} ({})", status, hex_str!(&code));
             response.extend_from_slice(&code).ok();

--- a/src/dispatch/apdu.rs
+++ b/src/dispatch/apdu.rs
@@ -56,7 +56,7 @@ where
         // "3. Client sends a command for an operation (register / authenticate)"
         // <https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-nfc-protocol-v1.2-ps-20170411.html>
 
-        Ok(match instruction {
+        match instruction {
             // U2F instruction codes
             // NB(nickray): I don't think 0x00 is a valid case.
             0x00 | 0x01 | 0x02 => super::try_handle_ctap1(self, apdu, response)?, //self.call_authenticator_u2f(apdu, response),
@@ -73,6 +73,7 @@ where
                     }
                 }
             }
-        })
+        };
+        Ok(())
     }
 }

--- a/src/dispatch/ctaphid.rs
+++ b/src/dispatch/ctaphid.rs
@@ -25,19 +25,20 @@ where
             msp() - 0x2000_0000
         );
 
-        if request.len() < 1 {
+        if request.is_empty() {
             debug_now!("invalid request length in ctaphid.call");
             return Err(ctaphid::Error::InvalidLength);
         }
 
         // info_now!("request: ");
         // blocking::dump_hex(request, request.len());
-        Ok(match command {
+        match command {
             ctaphid::Command::Cbor => super::handle_ctap2(self, request, response),
             ctaphid::Command::Msg => super::handle_ctap1_from_hid(self, request, response),
             _ => {
                 debug_now!("ctaphid trying to dispatch {:?}", command);
             }
-        })
+        };
+        Ok(())
     }
 }


### PR DESCRIPTION
Trussed itself already ignored this associated data (https://github.com/trussed-dev/trussed/pull/108), and the unwrapping was already performed with no associated data. Not removing it would lead to breakage once (https://github.com/trussed-dev/trussed/pull/108) is merged. Adding the AD to the unwrapping step would break compatibility with currently registerd credentials.

Security: This is not an issue because the credentials stored locally are encrypted with the proper app id as associated data which is checked when the credential is decrypted.

Also run `cargo fmt` and fix `clippy` warnings.