### PR TITLE
Set makeCredUvNotRqd in CTAP options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Set the `makeCredUvNotRqd` CTAP option to `true` to indicate that we support
+  makeCredential operations without user verification ([#26][])
+
+[#26]: https://github.com/solokeys/fido-authenticator/issues/26
+
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp
 - Add config option to skip UP when device was just booted,

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -81,6 +81,7 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 false => Some(false),
             },
             credential_mgmt_preview: Some(true),
+            make_cred_uv_not_rqd: Some(true),
             ..Default::default()
         };
         // options.rk = true;


### PR DESCRIPTION
This patch sets the makeCredUvNotRqd CTAP option to true to indicate that we support makeCredential operations without user verification. See also:
	https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html#getinfo-makecreduvnotrqd

Fixes: https://github.com/solokeys/fido-authenticator/issues/26