### PR TITLE
Ignore key parameters with unsupported type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
 - Set the `makeCredUvNotRqd` CTAP option to `true` to indicate that we support
   makeCredential operations without user verification ([#26][])
+- Ignore public key credential parameters with an unknown type, as required by
+  the Webauthn spec ([#28][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
+[#28]: https://github.com/solokeys/fido-authenticator/issues/28
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -199,6 +199,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         let mut algorithm: Option<SigningAlgorithm> = None;
         for param in parameters.pub_key_cred_params.iter() {
+            // Ignore unknown key types
+            if param.key_type != "public-key" {
+                continue;
+            }
+
             match param.alg {
                 -7 => {
                     if algorithm.is_none() {
@@ -212,15 +217,8 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
                 _ => {}
             }
         }
-        let algorithm = match algorithm {
-            Some(algorithm) => {
-                info_now!("algo: {:?}", algorithm as i32);
-                algorithm
-            }
-            None => {
-                return Err(Error::UnsupportedAlgorithm);
-            }
-        };
+        let algorithm = algorithm.ok_or(Error::UnsupportedAlgorithm)?;
+        info_now!("algo: {:?}", algorithm as i32);
 
         // 8. process options; on known but unsupported error UnsupportedOption
 


### PR DESCRIPTION
As required by the Webauthn spec, we now ignore public key credential parameters with a type other than "public-key".

Fixes: https://github.com/solokeys/fido-authenticator/issues/28