### PR TITLE
Reject RK option in get_assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   makeCredential operations without user verification ([#26][])
 - Ignore public key credential parameters with an unknown type, as required by
   the Webauthn spec ([#28][])
+- Reject `rk` option in getAssertion ([#31][])
 - Ignore user data with empty ID in getAssertion ([#32][])
 - Allow three instead of two PIN retries per boot ([#35][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
+[#31]: https://github.com/solokeys/fido-authenticator/issues/31
 [#32]: https://github.com/solokeys/fido-authenticator/issues/32
 [#35]: https://github.com/solokeys/fido-authenticator/issues/35
 

--- a/src/ctap2.rs
+++ b/src/ctap2.rs
@@ -921,6 +921,11 @@ impl<UP: UserPresence, T: TrussedRequirements> Authenticator for crate::Authenti
 
         // 6. process any options present
 
+        // RK is not supported in get_assertion
+        if parameters.options.as_ref().and_then(|options| options.rk).is_some() {
+            return Err(Error::InvalidOption);
+        }
+
         // UP occurs by default, but option could specify not to.
         let do_up = if parameters.options.is_some() {
             parameters.options.as_ref().unwrap().up.unwrap_or(true)


### PR DESCRIPTION
The getAssertion command does not use the rk option so we return an InvalidOption error if it is set.

Fixes: https://github.com/solokeys/fido-authenticator/pull/31