### PR TITLE
Allow three instead of two PIN retries per boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore public key credential parameters with an unknown type, as required by
   the Webauthn spec ([#28][])
 - Ignore user data with empty ID in getAssertion ([#32][])
+- Allow three instead of two PIN retries per boot ([#35][])
 
 [#26]: https://github.com/solokeys/fido-authenticator/issues/26
 [#28]: https://github.com/solokeys/fido-authenticator/issues/28
 [#32]: https://github.com/solokeys/fido-authenticator/issues/32
+[#35]: https://github.com/solokeys/fido-authenticator/issues/35
 
 ## [0.1.1] - 2022-08-22
 - Fix bug that treated U2F payloads as APDU over APDU in NFC transport @conorpp

--- a/src/state.rs
+++ b/src/state.rs
@@ -103,7 +103,7 @@ impl State {
 
     pub fn decrement_retries<T: TrussedClient>(&mut self, trussed: &mut T) -> Result<()> {
         self.persistent.decrement_retries(trussed)?;
-        self.runtime.decrement_retries()?;
+        self.runtime.decrement_retries();
         Ok(())
     }
 
@@ -452,14 +452,9 @@ impl PersistentState {
 impl RuntimeState {
     const POWERCYCLE_RETRIES: u8 = 3;
 
-    fn decrement_retries(&mut self) -> Result<()> {
+    fn decrement_retries(&mut self) {
         if self.consecutive_pin_mismatches < Self::POWERCYCLE_RETRIES {
             self.consecutive_pin_mismatches += 1;
-        }
-        if self.consecutive_pin_mismatches == Self::POWERCYCLE_RETRIES {
-            Err(Error::PinAuthBlocked)
-        } else {
-            Ok(())
         }
     }
 


### PR DESCRIPTION
Previously, a PinAuthBlocked error was already returned after two wrong PIN entries. The reason for this as that decrement_retries also checks if the allowed retries are exceeded. This as unnecessary because pin_blocked is always checked before decrement_retries is called.

This patch removes the check in decrement_retries.

Fixes: https://github.com/solokeys/fido-authenticator/issues/35