### PR TITLE
Cleanup Cargo.toml, publish from CI and release v0.2.0

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -1,0 +1,15 @@
+name: Continuous delivery - test
+
+on:
+  pull_request:
+    # opened, reopenened, synchronize are the default types for pull_request
+    # labeled, unlabeled ensure this check is also run if a label is added or removed
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  test-publish:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-publish-check') }}
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - run: cargo publish --dry-run

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,20 @@
+name: Continuous delivery - crates.io
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates.io
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879  # v1.0.1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+-
+
+## [v0.2.0](https://github.com/trussed-dev/fido-authenticator/releases/tag/v0.2.0) (2025-09-02)
+
 - Set the `makeCredUvNotRqd` CTAP option to `true` to indicate that we support
   makeCredential operations without user verification ([#26][])
 - Ignore public key credential paramters with an unknown type, as required by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fido-authenticator"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>", "Nitrokey GmbH"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,42 +1,41 @@
 [package]
 name = "fido-authenticator"
 version = "0.1.1"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+authors = ["The Trussed developers", "Nicolas Stalder <n@stalder.io>", "Nitrokey GmbH"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/solokeys/fido-authenticator"
+repository = "https://github.com/trussed-dev/fido-authenticator"
 documentation = "https://docs.rs/fido-authenticator"
 description = "FIDO authenticator Trussed app"
 
 [dependencies]
-cbor-smol = { version = "0.5" }
-ctap-types = { version = "0.4", features = ["get-info-full", "large-blobs", "third-party-payment"] }
+apdu-app = { version = "0.1", optional = true }
+cbor-smol = "0.5"
 cosey = "0.3"
-delog = "0.1.0"
+ctap-types = { version = "0.4", features = ["get-info-full", "large-blobs", "third-party-payment"] }
+ctaphid-app = { version = "0.1", optional = true }
+delog = "0.1"
 heapless = "0.7"
 heapless-bytes = "0.3"
+iso7816 = { version = "0.1.2", optional = true }
 littlefs2-core = "0.1"
 serde = { version = "1.0", default-features = false }
 serde_bytes = { version = "0.11.14", default-features = false }
-serde-indexed = "0.1.0"
+serde-indexed = "0.1"
 sha2 = { version = "0.10", default-features = false }
-trussed-core = { version = "0.1.0", features = ["aes256-cbc", "certificate-client", "chacha8-poly1305", "crypto-client", "ed255", "filesystem-client", "hmac-sha256", "management-client", "p256", "sha256", "ui-client"] }
-trussed-fs-info = "0.2.0"
-trussed-hkdf = { version = "0.3.0" }
-trussed-chunked = { version = "0.2.0", optional = true }
-
-apdu-app = { version = "0.1", optional = true }
-ctaphid-app = { version = "0.1.0-rc.1", optional = true }
-iso7816 = { version = "0.1.2", optional = true }
+trussed-chunked = { version = "0.2", optional = true }
+trussed-core = { version = "0.1", features = ["aes256-cbc", "certificate-client", "chacha8-poly1305", "crypto-client", "ed255", "filesystem-client", "hmac-sha256", "management-client", "p256", "sha256", "ui-client"] }
+trussed-fs-info = "0.2"
+trussed-hkdf = "0.3"
 
 [features]
-dispatch = ["apdu-dispatch", "ctaphid-dispatch", "iso7816"]
+dispatch = ["apdu-dispatch", "ctaphid-dispatch", "dep:iso7816"]
 apdu-dispatch = ["dep:apdu-app"]
 ctaphid-dispatch = ["dep:ctaphid-app"]
 disable-reset-time-window = []
 
 # enables support for a large-blob array longer than 1024 bytes
-chunked = ["trussed-chunked"]
+chunked = ["dep:trussed-chunked"]
 
 log-all = []
 log-none = []
@@ -50,18 +49,18 @@ log-error = []
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20", features = ["migration-tests"] }
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["alloc"] }
-ciborium = { version = "0.2.2" }
+ciborium = "0.2.2"
 ciborium-io = "0.2.2"
 cipher = "0.4.4"
 ctaphid = { version = "0.3.1", default-features = false }
 ctaphid-dispatch = "0.3"
 delog = { version = "0.1.6", features = ["std-log"] }
-env_logger = "0.11.0"
+env_logger = "0.11"
 hex-literal = "0.4.1"
 hmac = "0.12.1"
-interchange = "0.3.0"
-itertools = "0.14.0"
-littlefs2 = "0.6.0"
+interchange = "0.3"
+itertools = "0.14"
+littlefs2 = "0.6"
 log = "0.4.21"
 p256 = { version = "0.13.2", features = ["ecdh"] }
 rand = "0.8.4"
@@ -71,11 +70,11 @@ serde_test = "1.0.176"
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775", features = ["virt"] }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.3", features = ["chunked", "hkdf", "virt", "fs-info"] }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "504674453c9573a30aa2f155101df49eb2af1ba7", default-features = false, features = ["ctaphid"] }
-usbd-ctaphid = "0.3.0"
-x509-parser = "0.16.0"
+usbd-ctaphid = "0.3"
+x509-parser = "0.16"
 
 [package.metadata.docs.rs]
-features = ["dispatch"]
+features = ["chunked", "dispatch"]
 
 [patch.crates-io]
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log-warn = []
 log-error = []
 
 [dev-dependencies]
-admin-app = { version = "0.1.0", features = ["migration-tests"] }
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20", features = ["migration-tests"] }
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["alloc"] }
 ciborium = { version = "0.2.2" }
@@ -68,9 +68,9 @@ rand = "0.8.4"
 rand_chacha = "0.3"
 sha2 = "0.10"
 serde_test = "1.0.176"
-trussed = { version = "0.1", features = ["virt"] }
-trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt", "fs-info"] }
-trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775", features = ["virt"] }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.3", features = ["chunked", "hkdf", "virt", "fs-info"] }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "504674453c9573a30aa2f155101df49eb2af1ba7", default-features = false, features = ["ctaphid"] }
 usbd-ctaphid = "0.3.0"
 x509-parser = "0.16.0"
 
@@ -78,10 +78,7 @@ x509-parser = "0.16.0"
 features = ["dispatch"]
 
 [patch.crates-io]
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "7922d67e9637a87e5625aaff9e5111f0d4ec0346" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "504674453c9573a30aa2f155101df49eb2af1ba7" }
 
 [profile.test]
 opt-level = 2


### PR DESCRIPTION
This PR does some cleanup in Cargo.toml to prepare for publishing, adds a CI workflow to publish to crates.io and releases v0.2.0 with the changes merged from the Nitrokey fork.